### PR TITLE
Introduce alignment hints macro specifier

### DIFF
--- a/doc/align.qbk
+++ b/doc/align.qbk
@@ -49,6 +49,9 @@ and a function to verify pointer value alignment.
     [Type trait to query alignment requirement of a
       type at compile time]
   ]
+  [ [`assume_aligned`]
+    [Macros for static pointer alignment hints]
+  ]
   [ [`is_aligned`]
     [Pointer alignment verification function]
   ]
@@ -115,6 +118,12 @@ and also for C++03 compilers where it is equally useful.
 This library provides a function to test the alignment
 of a pointer value. It is generally useful in assertions
 to validate that memory is correctly aligned.
+
+[heading Alignment hints]
+
+Allocating aligned memory is sometimes not enough to ensure the optimal code
+generation. Developers may use specific intrinsics to notify the compiler of
+a given alignment properties of a memory block.
 
 [endsect]
 
@@ -391,6 +400,25 @@ int main()
 {
   alignas(16) char c[100];
   use(c, sizeof c);
+}
+``
+
+[endsect]
+
+[section assume_aligned]
+
+This macro is used to notify the compiler of a given pointer
+variable static alignment of a. It is useful to guide optimizing
+compilers into vectorizing or applying other compiler specific,
+alignment related optimizations.
+
+``
+void myfunc( double* p )
+{
+  BOOST_ALIGN_ASSUME_ALIGNED(p, 64);
+
+  for (int i=0; i<n; i++)
+    p[i]++;
 }
 ``
 
@@ -1170,6 +1198,30 @@ bool is_aligned(std::size_t alignment,
   [*Returns:] `true` if the value of `ptr` is aligned
   on the boundary specified by `alignment`, otherwise
   `false`.
+]
+
+[endsect]
+
+
+[section BOOST_ALIGN_ASSUME_ALIGNED]
+
+
+[heading:synopsis Header <boost/align/assume_aligned.hpp>]
+
+``
+#define BOOST_ALIGN_ASSUME_ALIGNED(PTR,ALIGN)
+``
+
+[heading:BOOST_ALIGN_ASSUME_ALIGNED Macro BOOST_ALIGN_ASSUME_ALIGNED]
+
+``
+BOOST_ALIGN_ASSUME_ALIGNED(PTR,ALIGN);
+``
+
+[: [*Requires:] `ALIGN` shall be a power of two. `PTR` shall be mutable.
+
+  [*Effect:] the `PTR` variable is modified in a compiler-specific
+  way to notify its alignment to the compiler.
 ]
 
 [endsect]

--- a/include/boost/align/assume_aligned.hpp
+++ b/include/boost/align/assume_aligned.hpp
@@ -1,0 +1,33 @@
+/*
+ (c) 2015 NumScale SAS
+ (c) 2015 LRI UMR 8623 CNRS/University Paris Sud XI
+
+ Distributed under the Boost Software
+ License, Version 1.0.
+ http://boost.org/LICENSE_1_0.txt
+*/
+#ifndef BOOST_ALIGN_ASSUME_ALIGNED_HPP_INCLUDED
+#define BOOST_ALIGN_ASSUME_ALIGNED_HPP_INCLUDED
+
+#include <boost/config.hpp>
+#include <cstddef>
+
+#if defined(BOOST_MSVC)
+
+#define BOOST_ALIGN_ASSUME_ALIGNED(PTR,ALIGN) __assume((std::size_t)(PTR) % (ALIGN) == 0)
+
+#elif defined(__INTEL_COMPILER)
+
+#define BOOST_ALIGN_ASSUME_ALIGNED(PTR,ALIGN)  __assume_aligned((PTR), (ALIGN))
+
+#elif defined(BOOST_GCC_VERSION) && (BOOST_GCC_VERSION >= 40700)
+
+#define BOOST_ALIGN_ASSUME_ALIGNED(PTR,ALIGN) (PTR) = __builtin_assume_aligned((PTR), (ALIGN))
+
+#else
+
+#define BOOST_ALIGN_ASSUME_ALIGNED(PTR,ALIGN)
+
+#endif
+
+#endif


### PR DESCRIPTION
Some compilers provide custom function to explicit the fact that a pointer is indded aligned on a given boundary. This PR introduces BOOST_ALIGN_ASSUME_ALIGNED to provide a portable way to use such hints.

Things to discuss :

 * is BOOST_ALIGN_ASSUME_ALIGNED a good name or can we short it to BOOST_ASSUME_ALIGNED ?

* is doc adequate ?
