### PR TITLE
Add align_{prev,next}

### DIFF
--- a/doc/align.qbk
+++ b/doc/align.qbk
@@ -52,6 +52,12 @@ verify pointer value alignment.
   [ [`is_aligned`]
     [Pointer alignment verification function]
   ]
+  [ [`align_next`]
+    [Get next alignment for given pointer or value]
+  ]
+  [ [`align_prev`]
+    [Get previous alignment for given pointer or value]
+  ]
 ]
 
 [endsect]
@@ -392,6 +398,69 @@ int main()
 {
     alignas(16) char c[64];
     use(c);
+}
+``
+
+[endsect]
+
+[section align_next]
+
+This function returns the *next* valid value or pointer for the given alignment.
+If it is already aligned with the good alignment, then `align_next` will return
+the same value.
+
+``
+#include <boost/align/align_next.hpp>
+#include <cassert>
+
+void use(std::size_t value)
+{
+    assert(boost::alignment::is_aligned(value, 16));
+}
+
+void use(void* ptr)
+{
+    assert(boost::alignment::is_aligned(ptr, 16));
+}
+
+int main()
+{
+    std::size_t addr = 0x3;
+    use(align_next(16, 16));
+    use(align_next(16, addr));
+    use(align_next(16, reinterpret_cast<void*>(16));
+    use(align_next(16, reinterpret_cast<void*>(addr));
+}
+``
+
+[endsect]
+
+[section align_prev]
+
+Same as `align_next` but will return the *previous* valid value or pointer for the
+given alignment.
+
+``
+#include <boost/align/align_prev.hpp>
+#include <cassert>
+
+void use(std::size_t value)
+{
+    assert(boost::alignment::is_aligned(value, 16));
+}
+
+void use(void* ptr)
+{
+    assert(boost::alignment::is_aligned(ptr, 16));
+}
+
+int main()
+{
+    std::size_t addr = 0x18;
+    use(align_prev(16, 16));
+    use(align_prev(16, addr));
+    use(align_prev(16, reinterpret_cast<void*>(16));
+    use(align_prev(16, reinterpret_cast<void*>(addr));
 }
 ``
 

--- a/include/boost/align.hpp
+++ b/include/boost/align.hpp
@@ -17,5 +17,7 @@ http://boost.org/LICENSE_1_0.txt
 #include <boost/align/alignment_of.hpp>
 #include <boost/align/assume_aligned.hpp>
 #include <boost/align/is_aligned.hpp>
+#include <boost/align/align_next.hpp>
+#include <boost/align/align_prev.hpp>
 
 #endif

--- a/include/boost/align/align_next.hpp
+++ b/include/boost/align/align_next.hpp
@@ -1,0 +1,16 @@
+/*
+(c) 2015 NumScale SAS
+
+(c) 2014 Glen Joseph Fernandes
+<glenjofe -at- gmail.com>
+
+Distributed under the Boost Software
+License, Version 1.0.
+http://boost.org/LICENSE_1_0.txt
+*/
+#ifndef BOOST_ALIGN_ALIGN_ON_HPP
+#define BOOST_ALIGN_ALIGN_ON_HPP
+
+#include <boost/align/detail/align_next.hpp>
+
+#endif

--- a/include/boost/align/align_prev.hpp
+++ b/include/boost/align/align_prev.hpp
@@ -1,0 +1,16 @@
+/*
+(c) 2015 NumScale SAS
+
+(c) 2014 Glen Joseph Fernandes
+<glenjofe -at- gmail.com>
+
+Distributed under the Boost Software
+License, Version 1.0.
+http://boost.org/LICENSE_1_0.txt
+*/
+#ifndef BOOST_ALIGN_ALIGN_PREV_HPP
+#define BOOST_ALIGN_ALIGN_PREV_HPP
+
+#include <boost/align/detail/align_prev.hpp>
+
+#endif

--- a/include/boost/align/detail/align_next.hpp
+++ b/include/boost/align/detail/align_next.hpp
@@ -1,0 +1,41 @@
+/*
+(c) 2015 NumScale SAS
+
+(c) 2014 Glen Joseph Fernandes
+<glenjofe -at- gmail.com>
+
+Distributed under the Boost Software
+License, Version 1.0.
+http://boost.org/LICENSE_1_0.txt
+*/
+#ifndef BOOST_ALIGN_DETAIL_ALIGN_ON_HPP
+#define BOOST_ALIGN_DETAIL_ALIGN_ON_HPP
+
+#include <boost/assert.hpp>
+#include <boost/config.hpp>
+#include <boost/align/detail/is_alignment.hpp>
+#include <cstdlib>
+
+namespace boost {
+namespace alignment {
+
+inline std::size_t align_next(std::size_t alignment, std::size_t value)
+    BOOST_NOEXCEPT
+{
+    BOOST_ASSERT(detail::is_alignment(alignment));
+    return (value + alignment - 1) & ~(alignment - 1);
+}
+
+template <class T>
+inline T* align_next(std::size_t alignment, T* ptr)
+    BOOST_NOEXCEPT
+{
+    BOOST_ASSERT(detail::is_alignment(alignment));
+    std::size_t addr = reinterpret_cast<std::size_t>(ptr);
+    return reinterpret_cast<T*>(::boost::alignment::align_next(alignment, addr));
+}
+
+} /* .alignment */
+} /* .boost */
+
+#endif

--- a/include/boost/align/detail/align_prev.hpp
+++ b/include/boost/align/detail/align_prev.hpp
@@ -1,0 +1,41 @@
+/*
+(c) 2015 NumScale SAS
+
+(c) 2014 Glen Joseph Fernandes
+<glenjofe -at- gmail.com>
+
+Distributed under the Boost Software
+License, Version 1.0.
+http://boost.org/LICENSE_1_0.txt
+*/
+#ifndef BOOST_ALIGN_DETAIL_ALIGN_PREV_HPP
+#define BOOST_ALIGN_DETAIL_ALIGN_PREV_HPP
+
+#include <boost/assert.hpp>
+#include <boost/config.hpp>
+#include <boost/align/detail/is_alignment.hpp>
+#include <cstdlib>
+
+namespace boost {
+namespace alignment {
+
+inline std::size_t align_prev(std::size_t alignment, std::size_t value)
+    BOOST_NOEXCEPT
+{
+    BOOST_ASSERT(detail::is_alignment(alignment));
+    return value & ~(alignment - 1);
+}
+
+template <class T>
+inline T* align_prev(std::size_t alignment, T* ptr)
+    BOOST_NOEXCEPT
+{
+    BOOST_ASSERT(detail::is_alignment(alignment));
+    std::size_t addr = reinterpret_cast<std::size_t>(ptr);
+    return reinterpret_cast<T*>(::boost::alignment::align_prev(alignment, addr));
+}
+
+} /* .alignment */
+} /* .boost */
+
+#endif

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -15,3 +15,5 @@ run aligned_delete_test.cpp ;
 run alignment_of_test.cpp ;
 run assume_aligned_test.cpp ;
 run is_aligned_test.cpp ;
+run align_next_test.cpp ;
+run align_prev_test.cpp ;

--- a/test/align_next_test.cpp
+++ b/test/align_next_test.cpp
@@ -1,0 +1,59 @@
+/*
+(c) 2015 NumScale SAS
+
+(c) 2014 Glen Joseph Fernandes
+<glenjofe -at- gmail.com>
+
+Distributed under the Boost Software
+License, Version 1.0.
+http://boost.org/LICENSE_1_0.txt
+*/
+
+#include <boost/align/align.hpp>
+#include <boost/align/is_aligned.hpp>
+#include <boost/align/align_next.hpp>
+#include <boost/core/lightweight_test.hpp>
+#include <cstddef>
+#include <iostream>
+
+template <std::size_t Alignment>
+void test()
+{
+    std::size_t value = 0x1;
+    std::size_t aligned_value = Alignment;
+    void* uptr = reinterpret_cast<void*>(value);
+    void* aptr = reinterpret_cast<void*>(aligned_value);
+    {
+      // `align_next` has no effect if the pointer has already the desired alignment
+      void* ptr = boost::alignment::align_next(Alignment, aptr);
+      BOOST_TEST(ptr == aptr);
+    }
+    {
+      void* ptr = boost::alignment::align_next(Alignment, uptr);
+      BOOST_TEST(ptr == aptr);
+    }
+    {
+      // `align_next` has no effect if the value has already the desired alignment
+      std::size_t val = boost::alignment::align_next(Alignment, aligned_value);
+      BOOST_TEST(val == aligned_value);
+    }
+    {
+      std::size_t val = boost::alignment::align_next(Alignment, value);
+      BOOST_TEST(val == aligned_value);
+    }
+}
+
+int main()
+{
+    std::cout << boost::alignment::align_next(16, 16) << std::endl;
+    test<1>();
+    test<2>();
+    test<4>();
+    test<8>();
+    test<16>();
+    test<32>();
+    test<64>();
+    test<128>();
+
+    return boost::report_errors();
+}

--- a/test/align_prev_test.cpp
+++ b/test/align_prev_test.cpp
@@ -1,0 +1,57 @@
+/*
+(c) 2015 NumScale SAS
+
+(c) 2014 Glen Joseph Fernandes
+<glenjofe -at- gmail.com>
+
+Distributed under the Boost Software
+License, Version 1.0.
+http://boost.org/LICENSE_1_0.txt
+*/
+
+#include <boost/align/align.hpp>
+#include <boost/align/is_aligned.hpp>
+#include <boost/align/align_prev.hpp>
+#include <boost/core/lightweight_test.hpp>
+#include <cstddef>
+
+template <std::size_t Alignment>
+void test()
+{
+    std::size_t value = (Alignment * 2) - 1;
+    std::size_t aligned_value = Alignment;
+    void* uptr = reinterpret_cast<void*>(value);
+    void* aptr = reinterpret_cast<void*>(aligned_value);
+    {
+      // `align_prev` has no effect if the pointer has already the desired alignment
+      void* ptr = boost::alignment::align_prev(Alignment, aptr);
+      BOOST_TEST(ptr == aptr);
+    }
+    {
+      void* ptr = boost::alignment::align_prev(Alignment, uptr);
+      BOOST_TEST(ptr == aptr);
+    }
+    {
+      // `align_prev` has no effect if the value has already the desired alignment
+      std::size_t val = boost::alignment::align_prev(Alignment, aligned_value);
+      BOOST_TEST(val == aligned_value);
+    }
+    {
+      std::size_t val = boost::alignment::align_prev(Alignment, value);
+      BOOST_TEST(val == aligned_value);
+    }
+}
+
+int main()
+{
+    test<1>();
+    test<2>();
+    test<4>();
+    test<8>();
+    test<16>();
+    test<32>();
+    test<64>();
+    test<128>();
+
+    return boost::report_errors();
+}


### PR DESCRIPTION
Hey there !

We've already discussed about adding those functions to `boost.align`.

Those functions get the previous or next valid alignment for the given couple of alignment and value or pointer. If the value or the pointer is already aligned with the good alignment, it is left unchanged!

Tell me if something is wrong with that PR. Thanks! :)

(@jfalcou ping)